### PR TITLE
fix(mpris): reset position and emit Seeked signal on track change

### DIFF
--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -301,6 +301,7 @@ impl Mpris {
     /// only for those properties.
     pub async fn publish(&self, next: MprisState) {
         let mut changed: Vec<Property> = Vec::new();
+        let mut track_changed = false;
         {
             let Ok(cur) = self.state.read() else { return };
             if cur.status != next.status {
@@ -308,6 +309,12 @@ impl Mpris {
             }
             if cur.track_key != next.track_key {
                 changed.push(Property::Metadata(next.metadata.clone()));
+                // Reset position if the track itself changed (not just cover art arriving)
+                let cur_vid = cur.track_key.split('|').next().unwrap_or("");
+                let next_vid = next.track_key.split('|').next().unwrap_or("");
+                if cur_vid != next_vid {
+                    track_changed = true;
+                }
             }
             if (cur.volume - next.volume).abs() > f64::EPSILON {
                 changed.push(Property::Volume(next.volume));
@@ -335,16 +342,23 @@ impl Mpris {
         if changed.is_empty() {
             return;
         }
-        // Keep the position we already have; `next` carries a stale one.
-        let position = self
-            .state
-            .read()
-            .map(|s| s.position)
-            .unwrap_or(Time::from_micros(0));
+        // If the track changed, reset position to the start; otherwise keep
+        // the position we already have (since `next` carries a stale one).
+        let position = if track_changed {
+            next.position
+        } else {
+            self.state
+                .read()
+                .map(|s| s.position)
+                .unwrap_or(Time::from_micros(0))
+        };
         if let Ok(mut s) = self.state.write() {
             *s = MprisState { position, ..next };
         }
         let _ = self.server.properties_changed(changed).await;
+        if track_changed {
+            let _ = self.server.emit(Signal::Seeked { position }).await;
+        }
     }
 
     /// Tell clients the position jumped, so their progress bars resync.


### PR DESCRIPTION
### Problem
In `src/mpris.rs`, when publishing state updates (`publish(next)`), `ytkew` intentionally preserves the current position with:
```rust
// Keep the position we already have; `next` carries a stale one.
let position = self.state.read().map(|s| s.position).unwrap_or(Time::from_micros(0));
```
While this works for periodic metadata/volume refreshes within the same song, it prevents the position from resetting when playback advances to a new song. MPRIS desktop clients and bar widgets (such as Waybar, AGS, Quickshell) continue to see the old track's ending position or fail to resync, causing the progress timeline to remain stuck or display elapsed times longer than the track's duration.

### Solution
1. Detect whether the track actually changed by checking the video ID part of `track_key` (`cur.track_key.split('|').next() != next.track_key.split('|').next()`).
2. If the track changed, reset `position` to `next.position` (0:00) rather than carrying over the previous track's position.
3. Emit `Signal::Seeked { position }` when a track change occurs so MPRIS clients receive an explicit resync notification and reset their timeline smoothly.