### PR TITLE
Add LRCLIB synced lyrics with ytmapi-rs fallback

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -32,6 +32,8 @@ still starts.
 | `volume_step` | `5.0` | Percent per keypress. |
 | `seek_step` | `5.0` | Seconds per keypress. |
 | `autoplay_radio` | `true` | Append a radio mix behind a played search hit. |
+| `lyrics_centered` | `true` | Centre lyric lines in the lyrics view. |
+| `lyrics_recenter` | `true` | Keep the playing line centred as synced lyrics advance. |
 | `save_repeat_shuffle` | `false` | Remember them across restarts. |
 | `accent_color` | `6` | ANSI index, used only as a last resort. |
 | `theme_colors` | — | Three hex strings, with `theme = "custom"`. |

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ pub use search::{SearchFilter, SearchHit, SEARCH_FILTERS};
 use crate::api::Api;
 use crate::art::{Cover, CoverLoader};
 use crate::config::{Config, Keymap};
+use crate::lyrics::Lyrics;
 use crate::model::Track;
 use crate::mpris::Mpris;
 use crate::palette::Palette;
@@ -93,7 +94,7 @@ pub enum AppMsg {
     },
     Lyrics {
         video_id: String,
-        text: String,
+        lyrics: Lyrics,
     },
     Error(String),
 }
@@ -132,9 +133,15 @@ pub struct App {
     pub search_sel: usize,
     pub searching: bool,
 
-    pub lyrics: Option<String>,
+    pub lyrics: Option<Lyrics>,
     pub lyrics_for: Option<String>,
     pub lyrics_scroll: u16,
+    /// Visible lyric rows from the last frame; the per-frame sync in run.rs
+    /// centres on the previous frame's height, which converges immediately.
+    pub(crate) lyrics_viewport_h: u16,
+    /// Auto-follow on (`sync_lyrics` recenters every frame) vs pinned by a
+    /// manual scroll (the user is reading, so per-frame sync stays off).
+    pub(crate) lyrics_follow: bool,
 
     pub status: Option<(String, Instant)>,
     pub should_quit: bool,
@@ -279,6 +286,9 @@ impl App {
             lyrics: None,
             lyrics_for: None,
             lyrics_scroll: 0,
+            lyrics_viewport_h: 20,
+            // Follow by default; a manual scroll pins until recenter/track change.
+            lyrics_follow: true,
             status: None,
             should_quit: false,
             cell_px: cfg_cell_px,
@@ -401,6 +411,8 @@ impl App {
         self.lyrics = None;
         self.lyrics_for = None;
         self.lyrics_scroll = 0;
+        // A new track follows by default until the user pins it manually.
+        self.lyrics_follow = true;
         self.cover = None;
         self.cover_for = Some(track.video_id.clone());
         self.clear_cover_art();
@@ -430,6 +442,34 @@ impl App {
                 });
             }
         }
+    }
+
+    /// Re-center `lyrics_scroll` on the line playing now. Called once per
+    /// frame from `run.rs`; plain lyrics have no timestamps so they are left
+    /// wherever the user put them.
+    pub(crate) fn sync_lyrics(&mut self, viewport_h: u16) {
+        // Both must allow follow: the config gate and the manual pin.
+        if !self.cfg.lyrics_recenter || !self.lyrics_follow {
+            return;
+        }
+        let Some(lyrics) = self.lyrics.as_ref() else {
+            return;
+        };
+        if !lyrics.is_synced {
+            return;
+        }
+        let pos = self.player_state.time_pos;
+        // mpv reports NaN while a stream is resolving, and a seek can briefly
+        // read negative; either would cast to a huge u32 and fling the scroll.
+        if !pos.is_finite() || pos < 0.0 {
+            return;
+        }
+        let Some(active) = lyrics.line_for((pos * 1000.0) as u32) else {
+            return;
+        };
+        let centered = active.saturating_sub(viewport_h as usize / 2);
+        let max = lyrics.lines.len().saturating_sub(viewport_h as usize);
+        self.lyrics_scroll = centered.min(max) as u16;
     }
 
     pub async fn next_track(&mut self) {
@@ -622,10 +662,12 @@ impl App {
                     self.cover = Some(*cover);
                 }
             }
-            AppMsg::Lyrics { video_id, text } => {
+            AppMsg::Lyrics { video_id, lyrics } => {
                 if self.queue.current().map(|t| t.video_id.as_str()) == Some(video_id.as_str()) {
                     self.lyrics_for = Some(video_id);
-                    self.lyrics = Some(text);
+                    self.lyrics = Some(lyrics);
+                    // Fresh lyrics follow by default until the user pins them.
+                    self.lyrics_follow = true;
                 }
             }
             AppMsg::Error(e) => {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -186,7 +186,11 @@ impl App {
 
     pub(crate) fn move_selection(&mut self, delta: isize) {
         if self.view == View::Lyrics {
+            // Manual scroll; Action::RecenterLyrics jumps back to the line
+            // playing now.
             self.lyrics_scroll = self.lyrics_scroll.saturating_add_signed(delta as i16);
+            // Pin the view so per-frame auto-follow stops fighting the user.
+            self.lyrics_follow = false;
             return;
         }
         // In columns, up and down stay within one level. Walking into
@@ -203,6 +207,36 @@ impl App {
             let next = (*sel as isize + delta).clamp(0, len as isize - 1);
             *sel = next as usize;
         }
+    }
+
+    /// One-shot jump back to the line playing now. Unlike `sync_lyrics`
+    /// this ignores `cfg.lyrics_recenter`, so the key works with
+    /// auto-center off; plain lyrics have no timestamps, so they reset
+    /// to the top.
+    pub(crate) fn recenter_lyrics(&mut self) {
+        // Resume auto-follow first: harmless when lyrics is None, and correct
+        // for when they arrive later.
+        self.lyrics_follow = true;
+        let Some(lyrics) = self.lyrics.as_ref() else {
+            return;
+        };
+        if !lyrics.is_synced {
+            self.lyrics_scroll = 0;
+            return;
+        }
+        let pos = self.player_state.time_pos;
+        // Same guard as `sync_lyrics`: NaN while resolving, or a briefly
+        // negative seek, would cast to a huge u32 and fling the scroll.
+        if !pos.is_finite() || pos < 0.0 {
+            return;
+        }
+        let Some(active) = lyrics.line_for((pos * 1000.0) as u32) else {
+            return;
+        };
+        let h = self.lyrics_viewport_h as usize;
+        let centered = active.saturating_sub(h / 2);
+        let max = lyrics.lines.len().saturating_sub(h);
+        self.lyrics_scroll = centered.min(max) as u16;
     }
 
     /// Jump to the first or last entry of the focused list.
@@ -444,6 +478,11 @@ impl App {
             Action::ShowLyrics => {
                 self.set_view(View::Lyrics);
                 self.ensure_lyrics();
+            }
+            Action::RecenterLyrics => {
+                if self.view == View::Lyrics {
+                    self.recenter_lyrics();
+                }
             }
             Action::ScrollUp => self.move_selection(-1),
             Action::ScrollDown => self.move_selection(1),

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -295,21 +295,26 @@ impl App {
         let api = self.api.clone();
         let tx = self.tx.clone();
         let vid = track.video_id.clone();
+        let title = track.title.clone();
+        let artist = track.artist.clone();
+        let album = track.album.clone();
+        let duration_secs = track
+            .duration
+            .unwrap_or_default()
+            .clamp(0.0, u64::MAX as f64) as u64;
         tokio::spawn(async move {
-            match api.lyrics(&vid).await {
-                Ok(text) => {
-                    let _ = tx.send(AppMsg::Lyrics {
-                        video_id: vid,
-                        text,
-                    });
-                }
-                Err(_) => {
-                    let _ = tx.send(AppMsg::Lyrics {
-                        video_id: vid,
-                        text: "no lyrics found".into(),
-                    });
-                }
-            }
+            let lyrics = crate::lyrics::fetch_lyrics(
+                &title,
+                &artist,
+                album.as_deref(),
+                duration_secs,
+                async { api.lyrics(&vid).await.ok() },
+            )
+            .await;
+            let _ = tx.send(AppMsg::Lyrics {
+                video_id: vid,
+                lyrics,
+            });
         });
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,11 @@ pub struct Config {
     /// Append a radio mix when a bare search is played, so one song does not
     /// leave you in silence.
     pub autoplay_radio: bool,
+    /// Centre lyric lines in the lyrics view.
+    pub lyrics_centered: bool,
+    /// Keep the playing line centred as synced lyrics advance. Off leaves
+    /// the scroll where j/k put it.
+    pub lyrics_recenter: bool,
 }
 
 impl Default for Config {
@@ -217,6 +222,8 @@ impl Default for Config {
             accent_color: 6,
             save_repeat_shuffle: false,
             autoplay_radio: true,
+            lyrics_centered: true,
+            lyrics_recenter: true,
         }
     }
 }
@@ -307,6 +314,8 @@ seek_step = 5.0
 
 autoplay_radio = true         # append a radio mix behind a played search hit
 save_repeat_shuffle = false   # remember shuffle/repeat across restarts
+lyrics_centered = true        # centre lyric lines in the lyrics view
+lyrics_recenter = true        # keep the playing line centred as synced lyrics advance
 hide_help = false
 "##;
 
@@ -333,6 +342,8 @@ mod tests {
         assert_eq!(c.accent_color, 6);
         assert!(c.color_from_cover);
         assert!(c.autoplay_radio);
+        assert!(c.lyrics_centered);
+        assert!(c.lyrics_recenter);
     }
 
     #[test]
@@ -343,6 +354,9 @@ mod tests {
         // Untouched fields fall back to the struct default, not zero.
         assert_eq!(c.visualizer_height, 6);
         assert_eq!(c.volume_step, 5.0);
+        // New lyrics keys are no different: an old file without them parses.
+        assert!(c.lyrics_centered);
+        assert!(c.lyrics_recenter);
     }
 
     #[test]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -41,6 +41,8 @@ pub enum Action {
     ShowSearch,
     ShowHelp,
     ShowLyrics,
+    /// Jump the lyrics scroll back to the line playing now.
+    RecenterLyrics,
     NextView,
     PrevView,
     CycleVisualizer,
@@ -173,6 +175,7 @@ impl Keymap {
             (F(5), NONE, ShowSearch),
             (F(6), NONE, ShowHelp),
             (Char('m'), NONE, ShowLyrics),
+            (Char('c'), NONE, RecenterLyrics),
             (Char('/'), NONE, ShowSearch),
             // Exit
             (Char('P'), SHIFT, PlayAll),
@@ -264,6 +267,9 @@ impl Keymap {
             (F(5), NONE, ShowSearch),
             (F(6), NONE, ShowHelp),
             (Char('m'), NONE, ShowLyrics),
+            // `c` already toggles cover art here, so recenter takes `z`:
+            // vim's own center-the-screen key.
+            (Char('z'), NONE, RecenterLyrics),
             (Char('/'), NONE, ShowSearch),
             (Char('P'), SHIFT, PlayAll),
             (Esc, NONE, ToggleMenu),
@@ -467,6 +473,7 @@ mod tests {
                 Action::Enqueue,
                 Action::ShowSearch,
                 Action::ShowLibrary,
+                Action::RecenterLyrics,
             ] {
                 assert!(
                     !km.keys_for(action).is_empty(),
@@ -484,6 +491,32 @@ mod tests {
         assert_eq!(KeyPreset::from_name("VIM"), KeyPreset::Vim);
         // An unknown preset falls back rather than leaving the app keyless.
         assert_eq!(KeyPreset::from_name("nonsense"), KeyPreset::Kew);
+    }
+
+    #[test]
+    fn recenter_lyrics_key_differs_where_c_is_taken() {
+        let kew = Keymap::for_preset(KeyPreset::Kew);
+        assert_eq!(
+            kew.resolve(KeyCode::Char('c'), KeyModifiers::NONE),
+            Some(Action::RecenterLyrics)
+        );
+        assert!(kew
+            .keys_for(Action::RecenterLyrics)
+            .contains(&"c".to_string()));
+        let vim = Keymap::for_preset(KeyPreset::Vim);
+        // `c` toggles cover art in the vim preset, so it keeps that meaning
+        // and recenter lives on `z` instead.
+        assert_eq!(
+            vim.resolve(KeyCode::Char('c'), KeyModifiers::NONE),
+            Some(Action::ToggleAscii)
+        );
+        assert_eq!(
+            vim.resolve(KeyCode::Char('z'), KeyModifiers::NONE),
+            Some(Action::RecenterLyrics)
+        );
+        assert!(vim
+            .keys_for(Action::RecenterLyrics)
+            .contains(&"z".to_string()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod browser;
 pub mod cli;
 pub mod config;
 pub mod desktop;
+pub mod lyrics;
 pub mod model;
 pub mod mpris;
 pub mod palette;

--- a/src/lyrics.rs
+++ b/src/lyrics.rs
@@ -1,0 +1,355 @@
+//! Lyrics: parsing, lookup, and the fallback chain.
+//!
+//! Pure data plus one HTTP client. No ratatui here on purpose -- the overlay
+//! reads [`Lyrics`] and renders; this module never touches the screen.
+//!
+//! Lookup order (Phase B wires the last step):
+//! LRCLIB synced > LRCLIB plain > `ytmapi-rs` > "no lyrics found".
+//!
+//! Phase B entry points: [`fetch_lyrics`] for the whole chain, or
+//! [`fetch_from_lrclib`] plus [`Lyrics::plain`] when the caller wants to own
+//! the fallback itself.
+
+/// One line of lyrics. `ms` is milliseconds since track start; plain
+/// (unsynced) lines all sit at 0.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LyricLine {
+    pub ms: u32,
+    pub text: String,
+}
+
+/// Owned lyrics for one track.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Lyrics {
+    pub lines: Vec<LyricLine>,
+    pub is_synced: bool,
+    /// "lrclib/synced" | "lrclib/plain" | "ytmapi" | "none".
+    pub source: String,
+    /// Line texts joined with `\n`, so plain consumers never need to care
+    /// whether timestamps existed.
+    pub raw: String,
+}
+
+impl Lyrics {
+    /// Untimed text: one line per row, every `ms` set to 0.
+    pub fn plain(text: String, source: &str) -> Self {
+        let lines = text
+            .lines()
+            .map(|l| LyricLine {
+                ms: 0,
+                text: l.to_string(),
+            })
+            .collect::<Vec<_>>();
+        Self {
+            raw: lines
+                .iter()
+                .map(|l| l.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            lines,
+            is_synced: false,
+            source: source.to_string(),
+        }
+    }
+
+    /// Parse LRC text. Untimed lines (including `[ti:]`/`[length:]` metadata)
+    /// are dropped; only timed lines survive. Empty text after a timestamp is
+    /// kept -- an empty timed line still advances the highlight over an
+    /// instrumental gap. Lines are sorted so [`Lyrics::line_for`] can binary
+    /// search; LRC files are usually sorted already, so this is nearly free.
+    pub fn parse_lrc(s: &str) -> Self {
+        let mut lines = Vec::new();
+        for raw_line in s.lines() {
+            let mut rest = raw_line.trim_start();
+            let mut stamps = Vec::new();
+            while let Some((ms, after)) = split_leading_timestamp(rest) {
+                stamps.push(ms);
+                rest = after;
+            }
+            if stamps.is_empty() {
+                continue;
+            }
+            // One line carrying several timestamps (a repeated chorus) fans
+            // out into one entry per stamp; the stable sort below keeps them
+            // in file order for equal timestamps.
+            let text = rest.trim().to_string();
+            for ms in stamps {
+                lines.push(LyricLine {
+                    ms,
+                    text: text.clone(),
+                });
+            }
+        }
+        lines.sort_by_key(|l| l.ms);
+        // Synced iff at least one timed line parsed -- even one with empty
+        // text, which still marks an instrumental gap for the highlight.
+        let is_synced = !lines.is_empty();
+        let raw = lines
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        Self {
+            lines,
+            is_synced,
+            source: "lrclib/synced".to_string(),
+            raw,
+        }
+    }
+
+    /// Index of the last line with `ms <= pos_ms`: the line to highlight.
+    /// `None` when there are no lines or playback hasn't reached the first.
+    pub fn line_for(&self, pos_ms: u32) -> Option<usize> {
+        let n = self.lines.partition_point(|l| l.ms <= pos_ms);
+        if n == 0 {
+            None
+        } else {
+            Some(n - 1)
+        }
+    }
+}
+
+/// Parse one leading `[mm:ss.xx]`/`[mm:ss.xxx]`/`[mm:ss]` tag, returning the
+/// timestamp in milliseconds and everything after the closing bracket.
+/// Anything else -- metadata like `[ti:title]`, garbage, a missing bracket --
+/// is `None`. Only the first tag is consumed; [`Lyrics::parse_lrc`] loops this
+/// to expand multi-stamp lines.
+pub fn parse_lrc_line(s: &str) -> Option<(u32, String)> {
+    let (ms, rest) = split_leading_timestamp(s.trim_start())?;
+    Some((ms, rest.trim().to_string()))
+}
+
+/// Split one leading `[tag]` off `s`. The tag must be a timestamp
+/// (`mm:ss` with an optional `.f`/`.ff`/`.fff` fraction); metadata tags fail
+/// the numeric parse and fall out as `None` with no special-casing.
+fn split_leading_timestamp(s: &str) -> Option<(u32, &str)> {
+    let rest = s.strip_prefix('[')?;
+    let end = rest.find(']')?;
+    let ms = parse_timestamp(&rest[..end])?;
+    Some((ms, &rest[end + 1..]))
+}
+
+fn parse_timestamp(tag: &str) -> Option<u32> {
+    let (mm, rest) = tag.split_once(':')?;
+    let minutes: u64 = mm.trim().parse().ok()?;
+    let (ss, frac) = match rest.split_once('.') {
+        Some((s, f)) => (s, f),
+        None => (rest, ""),
+    };
+    if ss.is_empty() || !ss.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let seconds: u64 = ss.trim().parse().ok()?;
+    let frac_ms: u64 = if frac.is_empty() {
+        0
+    } else {
+        if frac.len() > 3 || !frac.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let v: u64 = frac.parse().ok()?;
+        v * 10u64.pow(3 - frac.len() as u32)
+    };
+    // Clamp absurd values instead of overflowing: a garbage timestamp that
+    // parses should land at the end, not wrap to the start.
+    let total = minutes
+        .saturating_mul(60_000)
+        .saturating_add(seconds.saturating_mul(1000))
+        .saturating_add(frac_ms);
+    Some(total.min(u64::from(u32::MAX)) as u32)
+}
+
+// --- LRCLIB fetch ----------------------------------------------------------
+
+const LRCLIB_CACHED: &str = "https://lrclib.net/api/get-cached";
+const LRCLIB_GET: &str = "https://lrclib.net/api/get";
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LrclibResponse {
+    #[serde(default)]
+    synced_lyrics: Option<String>,
+    #[serde(default)]
+    plain_lyrics: Option<String>,
+    #[serde(default)]
+    instrumental: bool,
+}
+
+fn lrclib_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .user_agent(format!(
+            "ytkew/{} (https://github.com/dtDhruv/ytkew)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .unwrap_or_default()
+}
+
+/// One LRCLIB endpoint call. `None` means "try the next source", whatever the
+/// cause -- network error, 404 (unknown track), 429 (rate-limited; v1 just
+/// gives up and falls through rather than honouring Retry-After), or a body
+/// that doesn't decode. Collapsing them keeps the fallback chain to one
+/// `Option` with no error type Phase B must match on.
+async fn query_lrclib(
+    client: &reqwest::Client,
+    endpoint: &str,
+    title: &str,
+    artist: &str,
+    album: Option<&str>,
+    duration_secs: u64,
+) -> Option<LrclibResponse> {
+    let duration = duration_secs.to_string();
+    let mut req = client
+        .get(endpoint)
+        .query(&[("track_name", title), ("artist_name", artist)]);
+    if let Some(album) = album.filter(|a| !a.is_empty()) {
+        req = req.query(&[("album_name", album)]);
+    }
+    if duration_secs > 0 {
+        req = req.query(&[("duration", duration.as_str())]);
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    // `.text()` + `serde_json` rather than `.json()`: the crate is built with
+    // `default-features = false`, so the `json` response helper isn't there.
+    let body = resp.text().await.ok()?;
+    serde_json::from_str(&body).ok()
+}
+
+fn from_lrclib(res: LrclibResponse) -> Option<Lyrics> {
+    if let Some(synced) = res.synced_lyrics.filter(|s| !s.trim().is_empty()) {
+        let lyrics = Lyrics::parse_lrc(&synced);
+        if lyrics.is_synced {
+            return Some(lyrics);
+        }
+    }
+    if let Some(plain) = res.plain_lyrics.filter(|s| !s.trim().is_empty()) {
+        return Some(Lyrics::plain(plain, "lrclib/plain"));
+    }
+    if res.instrumental {
+        return Some(Lyrics::plain("instrumental".to_string(), "lrclib/plain"));
+    }
+    None
+}
+
+/// LRCLIB only: exact-match endpoint first, search endpoint second.
+/// `album` is `None`/empty-safe, `duration_secs` of 0 is simply not sent.
+pub async fn fetch_from_lrclib(
+    title: &str,
+    artist: &str,
+    album: Option<&str>,
+    duration_secs: u64,
+) -> Option<Lyrics> {
+    // ponytail: no disk cache, add when LRCLIB latency shows.
+    let client = lrclib_client();
+    for endpoint in [LRCLIB_CACHED, LRCLIB_GET] {
+        if let Some(res) =
+            query_lrclib(&client, endpoint, title, artist, album, duration_secs).await
+        {
+            if let Some(lyrics) = from_lrclib(res) {
+                return Some(lyrics);
+            }
+        }
+    }
+    None
+}
+
+/// Full chain: LRCLIB synced > LRCLIB plain > `ytm_fallback` (Phase B passes
+/// `api.lyrics(&video_id)` mapped to `Option`) > "no lyrics found".
+pub async fn fetch_lyrics(
+    title: &str,
+    artist: &str,
+    album: Option<&str>,
+    duration_secs: u64,
+    ytm_fallback: impl std::future::Future<Output = Option<String>>,
+) -> Lyrics {
+    if let Some(lyrics) = fetch_from_lrclib(title, artist, album, duration_secs).await {
+        return lyrics;
+    }
+    if let Some(text) = ytm_fallback.await.filter(|s| !s.trim().is_empty()) {
+        return Lyrics::plain(text, "ytmapi");
+    }
+    Lyrics::plain("no lyrics found".to_string(), "none")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_centisecond_timestamps() {
+        let l = Lyrics::parse_lrc("[00:17.12] hello\n[03:20.45] world\n");
+        assert!(l.is_synced);
+        assert_eq!(l.lines.len(), 2);
+        assert_eq!(l.lines[0].ms, 17_120);
+        assert_eq!(l.lines[0].text, "hello");
+        assert_eq!(l.lines[1].ms, 200_450);
+        assert_eq!(l.source, "lrclib/synced");
+    }
+
+    #[test]
+    fn parses_millisecond_and_bare_timestamps() {
+        let l = Lyrics::parse_lrc("[03:20.312] ms\n[01:02] bare\n");
+        assert!(l.is_synced);
+        assert_eq!(l.lines[0].ms, 62_000);
+        assert_eq!(l.lines[1].ms, 200_312);
+    }
+
+    #[test]
+    fn skips_malformed_lines_and_metadata() {
+        let l = Lyrics::parse_lrc(
+            "[ti:Title]\n[length: 03:45]\n[xx:yy] bad\n[00:10.00] ok\n\nplain line\n",
+        );
+        assert!(l.is_synced);
+        assert_eq!(l.lines.len(), 1);
+        assert_eq!(l.lines[0].text, "ok");
+    }
+
+    #[test]
+    fn expands_multiple_timestamps_on_one_line() {
+        let l = Lyrics::parse_lrc("[00:10.00][00:20.00] chorus\n");
+        assert_eq!(l.lines.len(), 2);
+        assert_eq!(l.lines[0].ms, 10_000);
+        assert_eq!(l.lines[1].ms, 20_000);
+        assert_eq!(l.lines[0].text, "chorus");
+    }
+
+    #[test]
+    fn line_for_returns_last_elapsed() {
+        let l = Lyrics::parse_lrc("[00:00.00] a\n[00:10.00] b\n[00:20.00] c\n");
+        assert_eq!(l.line_for(0), Some(0));
+        assert_eq!(l.line_for(15_000), Some(1));
+        assert_eq!(l.line_for(99_000), Some(2));
+    }
+
+    #[test]
+    fn line_for_returns_none_before_first_line_or_when_empty() {
+        let l = Lyrics::parse_lrc("[00:10.00] late\n");
+        assert_eq!(l.line_for(9_999), None);
+        let empty = Lyrics::parse_lrc("");
+        assert_eq!(empty.line_for(0), None);
+        assert!(!empty.is_synced);
+    }
+
+    #[test]
+    fn plain_marks_unsynced() {
+        let l = Lyrics::plain("one\ntwo".to_string(), "ytmapi");
+        assert!(!l.is_synced);
+        assert_eq!(l.lines.len(), 2);
+        assert!(l.lines.iter().all(|x| x.ms == 0));
+        assert_eq!(l.source, "ytmapi");
+        assert_eq!(l.raw, "one\ntwo");
+    }
+
+    #[test]
+    fn parse_lrc_line_reads_one_tag() {
+        assert_eq!(
+            parse_lrc_line("[00:17.12] hello"),
+            Some((17_120, "hello".to_string()))
+        );
+        assert_eq!(parse_lrc_line("[ti:Title]"), None);
+        assert_eq!(parse_lrc_line("no tag"), None);
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -115,6 +115,10 @@ pub async fn run(cli: Cli) -> Result<()> {
         // Pull the latest transport state before drawing so the progress bar
         // and clock never lag a frame behind.
         app.player_state = app.player.state().await;
+        // Pure arithmetic: re-center synced lyrics on the playing line using
+        // the last frame's viewport height.
+        let viewport_h = app.lyrics_viewport_h;
+        app.sync_lyrics(viewport_h);
         // Take the cover off screen before drawing anything that has to appear
         // over it. A pixel image is not part of the cell grid, so this has to
         // happen ahead of the frame -- blanking afterwards would erase what
@@ -127,6 +131,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             Ok(completed) => completed.area,
             Err(e) => break Err(e.into()),
         };
+        // Record the lyric viewport for the next frame's sync: body height
+        // minus the panel borders. Stale by one frame at most, and sync
+        // clamps, so a resize converges on the very next frame.
+        app.lyrics_viewport_h = ui::layout::body_rect(frame_area, &app)
+            .height
+            .saturating_sub(2);
         // Pixel graphics live outside ratatui's model, so the cover is written
         // after the frame, into cells the renderer deliberately skipped.
         if app.view == ui::View::Track && app.graphics_active() {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -298,6 +298,7 @@ fn pane_hints(app: &App) -> Vec<(String, &'static str)> {
         ],
         View::Lyrics => vec![
             (pair(Action::ScrollDown, Action::ScrollUp, "j/k"), "scroll"),
+            (key(Action::RecenterLyrics, "c"), "recenter"),
             (key(Action::NextView, "tab"), "back"),
         ],
         View::Help => vec![(key(Action::NextView, "tab"), "back")],

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -1,7 +1,7 @@
 //! Things drawn on top of a view: the menu, options, help and lyrics.
 
 use crate::app::App;
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph, Widget};
@@ -206,6 +206,9 @@ pub(super) fn draw_help(f: &mut Frame, area: Rect, app: &App) {
         ("Track view", k(ShowTrack)),
         ("Search view", k(ShowSearch)),
         ("Lyrics", k(ShowLyrics)),
+        ("Scroll lyrics up", k(ScrollUp)),
+        ("Scroll lyrics down", k(ScrollDown)),
+        ("Recenter lyrics", k(RecenterLyrics)),
         ("Help", k(ShowHelp)),
         ("Cycle views", k(NextView)),
         ("Quit", k(Quit)),
@@ -260,12 +263,55 @@ pub(super) fn draw_lyrics(f: &mut Frame, area: Rect, app: &App) {
     let Some(text) = &app.lyrics else {
         return centered_message(f, area, "fetching lyrics…");
     };
+    // Centre only when asked; the helper keeps the borrow checker happy
+    // across both branches below.
+    let align = |line: Line<'static>| {
+        if app.cfg.lyrics_centered {
+            line.alignment(Alignment::Center)
+        } else {
+            line
+        }
+    };
     let dim = app.palette.secondary().to_color();
+    if !text.is_synced {
+        let lines: Vec<Line> = text
+            .raw
+            .lines()
+            .skip(app.lyrics_scroll as usize)
+            .take(area.height as usize)
+            .map(|l| {
+                align(Line::from(Span::styled(
+                    l.to_string(),
+                    Style::default().fg(dim),
+                )))
+            })
+            .collect();
+        Paragraph::new(lines).render(area, f.buffer_mut());
+        return;
+    }
+    // mpv reports NaN while a stream is resolving; without the guard the
+    // cast below would highlight a garbage row for one frame.
+    let pos = app.player_state.time_pos;
+    let active = if pos.is_finite() && pos >= 0.0 {
+        text.line_for((pos * 1000.0) as u32)
+    } else {
+        None
+    };
+    let accent = app.palette.accent().to_color();
     let lines: Vec<Line> = text
-        .lines()
+        .lines
+        .iter()
+        .enumerate()
         .skip(app.lyrics_scroll as usize)
         .take(area.height as usize)
-        .map(|l| Line::from(Span::styled(l.to_string(), Style::default().fg(dim))))
+        .map(|(i, l)| {
+            let style = if Some(i) == active {
+                Style::default().fg(accent).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(dim)
+            };
+            align(Line::from(Span::styled(l.text.clone(), style)))
+        })
         .collect();
     Paragraph::new(lines).render(area, f.buffer_mut());
 }


### PR DESCRIPTION
`ytmapi-rs` only returns plain-text lyrics, so the lyrics view could never follow playback. This chains LRCLIB first and keeps ytmapi-rs as fallback.

**Fetch chain** — LRCLIB synced → LRCLIB plain → ytmapi-rs → "no lyrics found". Exact-match endpoint (`get-cached`) tried before search (`get`), 5s timeout, versioned `User-Agent`, 404/429 falls through instead of failing. All parsing/fetching isolated in a new `src/lyrics.rs` (regex-free LRC parser, no new dependencies).

**View** — lines render centered with the playing line highlighted (accent + bold), auto-following playback each frame.

**Reading vs following** — auto-follow used to stomp manual scroll, so `j/k` now pins the view until recenter, track change, or fresh lyrics arrive.

**Options** (`config.toml`)

- `lyrics_centered = true` — center lyric lines
- `lyrics_recenter = true` — keep the playing line centered as synced lyrics advance

**Keys**

- `c` (kew) / `z` (vim) — recenter on the playing line, works even with auto-center off (`c` was already taken by the cover-art toggle in the vim preset)
- Help view and the lyrics footer now document scroll + recenter (scroll keys were previously bound but listed nowhere)

Old config files without the new keys still parse (serde defaults). Verified with `cargo test` (197 passed), both clippy invocations, and `cargo fmt --check`.

closes #15 