### PR TITLE
Detect sixel by measurement and query, not a name list

### DIFF
--- a/src/app/graphics.rs
+++ b/src/app/graphics.rs
@@ -125,11 +125,14 @@ impl App {
                 self.graphics = Graphics::resolve(&self.cfg, self.cell_source);
             }
         }
-        if self.graphics == Graphics::None
-            && self.cfg.cover_mode == crate::config::CoverMode::Auto
-            && crate::art::terminal::terminal_supports_sixel()
-        {
-            if let Some(mux) = crate::art::terminal::multiplexer() {
+        // The multiplexer check is a cheap env read and rules this out for
+        // almost everyone; `terminal_supports_sixel` can query the terminal,
+        // so it goes last.
+        if let Some(mux) = crate::art::terminal::multiplexer() {
+            if self.graphics == Graphics::None
+                && self.cfg.cover_mode == crate::config::CoverMode::Auto
+                && crate::art::terminal::terminal_supports_sixel()
+            {
                 self.notify(format!(
                     "cover: half-blocks — sixel renders at the wrong size under {mux} \
                      (zellij#3372). Press b for sixel, then [ / ] to resize."

--- a/src/art/terminal.rs
+++ b/src/art/terminal.rs
@@ -312,20 +312,69 @@ pub fn multiplexer() -> Option<&'static str> {
 /// sized, so a multiplexer gets those unless the user has explicitly pinned a
 /// cell size to compensate.
 pub fn sixel_recommended(source: CellSource) -> bool {
-    if !terminal_supports_sixel() || !source.is_trustworthy() {
-        return false;
-    }
-    match multiplexer() {
-        // A pinned size means the user has tuned it themselves.
-        Some(_) => source == CellSource::Config,
-        None => true,
-    }
+    sixel_ok(source, terminal_supports_sixel, multiplexer().is_some())
 }
 
-/// Whether this terminal is known to render sixel. There is a DA1 query that
-/// would answer definitively, but matching the environment covers the common
-/// terminals and the config can always override.
+/// Split out from the environment lookups so it can be tested. `env_supports`
+/// is deferred because it can query the terminal, which must not happen when
+/// the answer cannot change the outcome.
+fn sixel_ok(source: CellSource, env_supports: impl FnOnce() -> bool, in_mux: bool) -> bool {
+    if !source.is_trustworthy() {
+        return false;
+    }
+    // `calibrate` proves support by drawing a probe and reading the cursor
+    // back, so a measurement outranks any list of names. A pinned `cell_px`
+    // skips the probe, so that case still needs the list.
+    if source != CellSource::Calibrated && !env_supports() {
+        return false;
+    }
+    if in_mux {
+        // A pinned size means the user has tuned it themselves.
+        return source == CellSource::Config;
+    }
+    true
+}
+
+/// Whether this terminal renders sixel.
+///
+/// Memoised because it writes to the tty and reads the answer back, which is
+/// only safe before an input reader exists.
 pub fn terminal_supports_sixel() -> bool {
+    static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPORTED.get_or_init(|| env_supports_sixel() || da1_supports_sixel())
+}
+
+/// Ask the terminal directly: DA1 (`CSI c`) answers `CSI ? <attrs> c`, and
+/// attribute 4 is sixel. Works for any terminal, named or not.
+fn da1_supports_sixel() -> bool {
+    let Some(mut tty) = open_tty() else {
+        return false;
+    };
+    let Some(raw) = RawMode::enable(&tty) else {
+        return false;
+    };
+    let reply = (|| {
+        use std::io::Write;
+        tty.write_all(b"\x1b[c").ok()?;
+        tty.flush().ok()?;
+        read_reply(&mut tty, b'c', 250)
+    })();
+    drop(raw);
+    reply.is_some_and(|r| da1_lists_sixel(&r))
+}
+
+fn da1_lists_sixel(reply: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(reply);
+    let Some(start) = text.find('?') else {
+        return false;
+    };
+    let attrs = &text[start + 1..];
+    let end = attrs.find('c').unwrap_or(attrs.len());
+    attrs[..end].split(';').any(|a| a.trim() == "4")
+}
+
+/// Terminals known by name. Kept only to skip the DA1 round trip.
+fn env_supports_sixel() -> bool {
     if let Ok(p) = std::env::var("TERM_PROGRAM") {
         let p = p.to_ascii_lowercase();
         if ["wezterm", "mlterm", "contour", "iterm.app"]
@@ -391,6 +440,50 @@ mod tests {
         assert!(!CellSource::Fallback.is_trustworthy());
         assert!(CellSource::Config.is_trustworthy());
         assert!(CellSource::Calibrated.is_trustworthy());
+    }
+
+    #[test]
+    fn a_measured_size_enables_sixel_in_an_unlisted_terminal() {
+        // Absent from every list, but the probe says yes.
+        assert!(sixel_ok(CellSource::Calibrated, || false, false));
+    }
+
+    #[test]
+    fn an_unmeasured_size_still_needs_the_environment_list() {
+        // No probe ran, so nothing has proven sixel works.
+        assert!(!sixel_ok(CellSource::Config, || false, false));
+        assert!(sixel_ok(CellSource::Config, || true, false));
+    }
+
+    #[test]
+    fn a_guessed_size_never_enables_sixel_however_capable_the_terminal() {
+        for source in [CellSource::Query, CellSource::Ioctl, CellSource::Fallback] {
+            assert!(!sixel_ok(source, || true, false), "{source:?}");
+        }
+    }
+
+    #[test]
+    fn a_measurement_does_not_override_the_multiplexer_rule() {
+        // zellij#3372: double height, and nothing reveals it.
+        assert!(!sixel_ok(CellSource::Calibrated, || true, true));
+        assert!(sixel_ok(CellSource::Config, || true, true));
+    }
+
+    #[test]
+    fn a_da1_reply_listing_attribute_four_means_sixel() {
+        assert!(da1_lists_sixel(b"\x1b[?62;4;6;9;22c"));
+        assert!(da1_lists_sixel(b"\x1b[?64;1;2;4c"));
+        assert!(da1_lists_sixel(b"\x1b[?4c"));
+    }
+
+    #[test]
+    fn a_da1_reply_without_it_does_not() {
+        assert!(!da1_lists_sixel(b"\x1b[?62;22c"));
+        assert!(!da1_lists_sixel(b"\x1b[?1;2c"));
+        // 4 must be an attribute of its own, not a digit inside one.
+        assert!(!da1_lists_sixel(b"\x1b[?62;40;14c"));
+        assert!(!da1_lists_sixel(b""));
+        assert!(!da1_lists_sixel(b"garbage"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,24 @@ pub async fn run_diagnose(cfg_dir: &std::path::Path) -> Result<()> {
         std::env::var("TERM").unwrap_or_default(),
         std::env::var("TERM_PROGRAM").unwrap_or_default()
     );
+    // Several terminals are invisible in the line above, identifying
+    // themselves only through their own variable.
+    for key in [
+        "KONSOLE_VERSION",
+        "VTE_VERSION",
+        "KITTY_WINDOW_ID",
+        "WEZTERM_PANE",
+        "ALACRITTY_WINDOW_ID",
+        "GHOSTTY_BIN_DIR",
+        "ITERM_SESSION_ID",
+        "CONTOUR_VERSION",
+        "WT_SESSION",
+        "TERMUX_VERSION",
+    ] {
+        if let Ok(v) = std::env::var(key) {
+            println!("  {key}={v}");
+        }
+    }
     println!(
         "  multiplexer:     {}",
         art::terminal::multiplexer().unwrap_or("none")


### PR DESCRIPTION
Sixel support was decided by matching TERM and TERM_PROGRAM against a hardcoded set of terminal names, so a capable terminal absent from that set drew half-blocks instead. Two general signals replace the guess.

`calibrate` already drew a probe sixel and read the cursor back, which proves the terminal drew it -- the comment on `CellSource` called it "the only source that reflects what the terminal actually does with sixel" -- but `sixel_recommended` tested the name list first and threw the measurement away. A `Calibrated` size is now sufficient on its own.

For the one path that skips the probe, a pinned `cell_px`, DA1 (`CSI c`) asks the terminal outright, where attribute 4 means sixel. It is memoised, since it reads a reply and so is only safe before the input reader starts. The name list survives purely as a way to skip that round trip.

That query is passed as a closure rather than a value. Evaluated eagerly it ran whenever anything asked whether sixel was recommended -- including for cover modes that cannot draw it, for untrustworthy cell sizes that reject it a line later, and from the test suite, which has no business writing escape sequences to a tty. Deferred, it runs only when a pinned cell size leaves the name list as the deciding factor.

The multiplexer check in `calibrate_cells` moves ahead of it for the same reason: a cheap environment read that rules the branch out for almost everyone should not sit behind one that can talk to the terminal.

The multiplexer rule itself is unchanged: zellij#3372 renders sixel at double height and reports nothing that reveals it, so only a hand-tuned size is trusted there.

--diagnose now prints the variables terminals identify themselves through, several of which never appear in TERM.