### PR TITLE
Remember the renderer chosen from the menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -158,6 +158,9 @@ pub struct App {
     pub cover_visible: bool,
     /// Active theme name. "cover" means take the colours from the artwork.
     pub theme: String,
+    /// Renderer picked from the menu this session or a previous one. `None`
+    /// means the menu was never used and `config.toml` stays in charge.
+    pub cover_mode_override: Option<crate::config::CoverMode>,
     /// Built-in themes plus anything the user dropped in `themes/`.
     pub themes: crate::theme::Themes,
 
@@ -227,6 +230,12 @@ impl App {
                 _ => RepeatMode::Off,
             };
         }
+        // A menu choice outranks the config. Must precede `Graphics::resolve`.
+        let cover_mode_override = crate::config::CoverMode::from_name(&state.cover_mode);
+        let mut cfg = cfg;
+        if let Some(mode) = cover_mode_override {
+            cfg.cover_mode = mode;
+        }
         let cfg_accent = cfg.accent_color;
         // First run falls back to the config's default; after that the
         // remembered toggle wins.
@@ -288,6 +297,7 @@ impl App {
             pending_seek: None,
             cover_visible: state_cover_visible,
             theme: active_theme,
+            cover_mode_override,
             themes,
             menu_open: false,
             side_pane_open: false,
@@ -321,6 +331,10 @@ impl App {
             },
             cover_visible: self.cover_visible,
             theme: self.theme.clone(),
+            cover_mode: self
+                .cover_mode_override
+                .map(|m| m.name().to_string())
+                .unwrap_or_default(),
             shuffle: self.queue.shuffle,
             repeat: match self.queue.repeat {
                 RepeatMode::All => "all".into(),

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -220,6 +220,7 @@ impl App {
                     "blocks" => CoverMode::Blocks,
                     _ => CoverMode::Auto,
                 };
+                self.cover_mode_override = Some(self.cfg.cover_mode);
                 self.graphics = Graphics::resolve(&self.cfg, self.cell_source);
             }
             Setting::ShowCover => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,7 +156,17 @@ pub async fn run_auth(method: &str, cfg_dir: &std::path::Path) -> Result<()> {
 pub async fn run_diagnose(cfg_dir: &std::path::Path) -> Result<()> {
     // Probe first: the measurement needs a screen it can draw on without
     // scrolling, so it must happen before anything is printed.
+    // State outranks the config for both of these, exactly as run.rs applies
+    // them, or this reports settings the running app does not use.
     let cfg_probe = config::Config::load(cfg_dir);
+    let state_probe = config::State::load(cfg_dir, &cfg_probe);
+    let mut cfg_probe = cfg_probe;
+    if cfg_probe.cell_px == [0, 0] && state_probe.cover_cell != [0, 0] {
+        cfg_probe.cell_px = state_probe.cover_cell;
+    }
+    if let Some(mode) = config::CoverMode::from_name(&state_probe.cover_mode) {
+        cfg_probe.cover_mode = mode;
+    }
     let ((cw, ch), src) = art::terminal::detect_cell_size(match cfg_probe.cell_px {
         [w, h] if w > 0 && h > 0 => Some((w, h)),
         _ => None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,18 @@ impl CoverMode {
     pub fn draws_anything(self) -> bool {
         !matches!(self, CoverMode::Off)
     }
+
+    /// `None` for empty or unknown input, meaning "use the config".
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(CoverMode::Auto),
+            "kitty" => Some(CoverMode::Kitty),
+            "sixel" => Some(CoverMode::Sixel),
+            "blocks" => Some(CoverMode::Blocks),
+            "off" => Some(CoverMode::Off),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/src/config/state.rs
+++ b/src/config/state.rs
@@ -22,6 +22,8 @@ pub struct State {
     pub cover_visible: bool,
     /// Theme chosen at runtime with `t`. Empty means "use the config".
     pub theme: String,
+    /// Renderer chosen from the menu. Empty means "use the config".
+    pub cover_mode: String,
 }
 
 impl Default for State {
@@ -33,6 +35,7 @@ impl Default for State {
             cover_cell: [0, 0],
             cover_visible: true,
             theme: String::new(),
+            cover_mode: String::new(),
         }
     }
 }
@@ -93,6 +96,7 @@ mod tests {
             cover_cell: [12, 24],
             cover_visible: false,
             theme: "nord".into(),
+            cover_mode: "sixel".into(),
         };
         saved.save(&dir).unwrap();
         let back = State::load(&dir, &cfg);
@@ -102,7 +106,52 @@ mod tests {
         assert_eq!(back.cover_cell, [12, 24], "tuned cell size must persist");
         assert!(!back.cover_visible, "the b toggle must persist");
         assert_eq!(back.theme, "nord", "the chosen theme must persist");
+        assert_eq!(
+            back.cover_mode, "sixel",
+            "a renderer chosen from the menu must persist"
+        );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_unset_renderer_leaves_the_config_in_charge() {
+        // A first run, or a state.toml written before this field existed.
+        use crate::config::CoverMode;
+        assert_eq!(CoverMode::from_name(""), None);
+        assert_eq!(CoverMode::from_name("nonsense"), None);
+        assert_eq!(State::default().cover_mode, "");
+    }
+
+    #[test]
+    fn an_untouched_menu_leaves_config_toml_in_charge() {
+        // Saving the effective mode every exit would pin the first run's
+        // value forever, so editing cover_mode in config.toml would stop
+        // working from the second launch on.
+        let dir = std::env::temp_dir().join(format!("ytkew-cm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        State::default().save(&dir).unwrap();
+        let back = State::load(&dir, &Config::default());
+        assert_eq!(
+            back.cover_mode, "",
+            "no menu choice must leave the field empty"
+        );
+        assert_eq!(crate::config::CoverMode::from_name(&back.cover_mode), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn every_renderer_name_round_trips_through_its_parser() {
+        // `name` is what gets saved; a mismatch reverts the choice.
+        use crate::config::CoverMode;
+        for mode in [
+            CoverMode::Auto,
+            CoverMode::Kitty,
+            CoverMode::Sixel,
+            CoverMode::Blocks,
+            CoverMode::Off,
+        ] {
+            assert_eq!(CoverMode::from_name(mode.name()), Some(mode), "{mode:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
The options pane offers a cover renderer alongside the theme, but only the theme was saved, so a renderer picked there silently reverted on the next launch. `State` now carries it, the way it already carries the theme and the eye-tuned cell size.

Only an explicit menu choice is written. Saving the effective mode on every exit would be simpler, but `name` never yields an empty string, so the first run would pin a value forever and editing `cover_mode` in `config.toml` would stop having any effect from the second launch on. `None` keeps the config authoritative; a menu choice overrides it.

--diagnose applies the same state-over-config merges that run.rs does. It read `Config` alone, so it already reported a cell size the running app was not using once one had been tuned with `[` and `]`, and would have done the same for the renderer.

`from_name` and `name` are covered by a round-trip test, since a disagreement between them would present as the setting quietly resetting.